### PR TITLE
fix: add unsafe-eval to script-src to fix broken prod

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; connect-src 'self' https://forodain-api.luthien-labs.net; img-src 'self' https: data:; style-src 'self' 'unsafe-inline'; font-src 'self'; base-uri 'self'; form-action 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-eval'; connect-src 'self' https://forodain-api.luthien-labs.net; img-src 'self' https: data:; style-src 'self' 'unsafe-inline'; font-src 'self'; base-uri 'self'; form-action 'none';" />
     <meta name="robots" content="noindex" />
     <meta name="googlebot" content="noindex" />
     <link rel="icon" type="image/png" href="/img/spear-emblem-t.png" />


### PR DESCRIPTION
## What broke and why

After merging #5, prod rendered a blank unstyled page. The root cause:

Both the React production bundle and `scroll-timeline.js` use the `Function()` constructor at runtime (11 and 3 occurrences respectively). `Function()` is treated as `eval` by CSP and is blocked by `script-src 'self'` without `'unsafe-eval'`. This caused the JS bundle to throw silently on load, leaving `<div id="root">` empty — the CSS file loads fine but there's nothing to style.

## Fix

Add `'unsafe-eval'` to `script-src`:

```
script-src 'self' 'unsafe-eval'
```

## Note on security trade-off

`'unsafe-eval'` weakens the XSS protection that `script-src` provides. For this site (read-only, no auth, no user data), the practical risk is low. Eliminating it properly would require patching or replacing the `Function()` calls in both React internals and the scroll-timeline polyfill — not practical here.

## Test plan

- [ ] Merge and redeploy
- [ ] Confirm styles render correctly at https://forodain.luthien-labs.net
- [ ] No CSP violation errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)