### PR TITLE
fix: allow blob: in style-src, remove unsafe-eval

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-eval'; connect-src 'self' https://forodain-api.luthien-labs.net; img-src 'self' https: data:; style-src 'self' 'unsafe-inline'; font-src 'self'; base-uri 'self'; form-action 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; connect-src 'self' https://forodain-api.luthien-labs.net; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' blob:; font-src 'self'; base-uri 'self'; form-action 'none';" />
     <meta name="robots" content="noindex" />
     <meta name="googlebot" content="noindex" />
     <link rel="icon" type="image/png" href="/img/spear-emblem-t.png" />


### PR DESCRIPTION
## What was wrong

The scroll-timeline polyfill uses the [Constructable Stylesheets API](https://developer.chrome.com/docs/css-ui/constructable-stylesheets) — it creates a `Blob`, generates a `blob:` object URL, and applies it as a stylesheet at runtime. This was blocked by `style-src 'self' 'unsafe-inline'` because `blob:` must be explicitly permitted.

Browser console error that identified it:
```
Content-Security-Policy: The page's settings blocked a style (style-src-elem)
at blob:https://forodain.luthien-labs.net/... from being applied because it
violates the following directive: "style-src 'self' 'unsafe-inline'"
```

## Changes

- Add `blob:` to `style-src`
- Remove `'unsafe-eval'` from `script-src` — added speculatively in the previous fix but the bundle doesn't actually use `eval` or `new Function()` anywhere

## Final policy

```
default-src 'none';
script-src 'self';
connect-src 'self' https://forodain-api.luthien-labs.net;
img-src 'self' https: data:;
style-src 'self' 'unsafe-inline' blob:;
font-src 'self';
base-uri 'self';
form-action 'none';
```

## Test plan

- [ ] Merge and redeploy
- [ ] Confirm styles render correctly at https://forodain.luthien-labs.net
- [ ] No CSP violations in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)